### PR TITLE
Better implementation of the activity constraint

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,18 @@ yyyy-mm-dd Your Name <your@email.com>
 	* file ( method in file ) : changes.
 ###
 
+2019-03-09 Inge Wortel <ingewortel@gmail.com>
+	* hamiltonian/ActivityConstraint2.js : Added new implementation of the activity
+	constraint that directly tracks activity values in an object instead of their birth
+	time. This implementation should be more efficient because pixels are removed once
+	their activity reaches zero.
+		!!! We may want to make a test that checks if two implementations do the same
+		thing?
+	* app/index.js : use ActivityConstraint2.js instead of ActivityConstraint.js for
+	the build.
+	* examples/actmodel.html : fixed bug because of change in CPM.js file. Added a 
+	perimeter constraint to the cell.
+
 2019-03-09 Johannes Textor <johannes.textor@gmx.de>
 	* hamiltonian/Constraint.js : new base class for all constraints
 	* CPM.js: renamed addTerm to simply "add" -- we may want to add other

--- a/app/index.js
+++ b/app/index.js
@@ -14,7 +14,7 @@ import VolumeConstraint from "../hamiltonian/VolumeConstraint.js"
 import HardVolumeRangeConstraint from "../hamiltonian/HardVolumeRangeConstraint.js"
 import TestLogger from "../hamiltonian/TestLogger.js"
 import PerimeterConstraint from "../hamiltonian/PerimeterConstraint.js"
-import ActivityConstraint from "../hamiltonian/ActivityConstraint.js"
+import ActivityConstraint from "../hamiltonian/ActivityConstraint2.js"
 
 export {CPM,CPMChemotaxis,Stats,Canvas,GridManipulator,Grid2D,Grid3D,
 	Adhesion, VolumeConstraint, GridInitializer, HardVolumeRangeConstraint, TestLogger,

--- a/build/cpm-cjs.js
+++ b/build/cpm-cjs.js
@@ -1864,7 +1864,7 @@ class ActivityConstraint extends SoftConstraint {
 	constructor( conf ){
 		super( conf );
 
-		this.cellpixelsbirth = {}; // time the pixel was added to its current cell.
+		this.cellpixelsact = {}; // activity of cellpixels with a non-zero activity
 		
 		// Wrapper: select function to compute activities based on ACT_MEAN in conf
 		if( this.conf.ACT_MEAN == "arithmetic" ){
@@ -1874,6 +1874,7 @@ class ActivityConstraint extends SoftConstraint {
 		}
 		
 	}
+	
 	/* ======= ACT MODEL ======= */
 
 	/* Act model : compute local activity values within cell around pixel i.
@@ -1974,22 +1975,33 @@ class ActivityConstraint extends SoftConstraint {
 	/* Current activity (under the Act model) of the pixel with ID i. */
 	pxact ( i ){
 	
-		// If the pixel is not in the cellpixelsbirth object, it has activity 0.
-		/*if ( !this.cellpixelsbirth[i] ){
+		// If the pixel is not in the cellpixelsact object, it has activity 0.
+		if ( this.cellpixelsact[i] == undefined ){
 			return 0
-		}*/
+		}
+		// otherwise, its activity is stored in the object.
+		return this.cellpixelsact[i]
 		
-		// cellkind of current pixel
-		const k = this.C.cellKind( this.C.pixti(i) );
-		
-		// Activity info
-		const actmax = this.conf["MAX_ACT"][k], age = (this.C.time - this.cellpixelsbirth[i]);
-
-		return (age > actmax) ? 0 : actmax-age
 	}
+	
 	/* eslint-disable no-unused-vars*/
 	postSetpixListener( i, t_old, t ){
-		this.cellpixelsbirth[i] = this.C.time;
+	
+		// After setting a pixel, it gets the MAX_ACT value of its cellkind.
+		const k = this.C.cellKind( t );
+		this.cellpixelsact[i] = this.conf["MAX_ACT"][k];
+	}
+	
+	postMCSListener(){
+		// iterate over cellpixelsage and decrease all activities by one.
+		for( let key in this.cellpixelsact ){
+			this.cellpixelsact[ key ] = this.cellpixelsact[ key ] - 1;
+			
+			// activities that reach zero no longer need to be stored.
+			if( this.cellpixelsact[ key ] <= 0 ){
+				delete this.cellpixelsact[ key ];
+			}
+		}
 	}
 
 

--- a/build/cpm.js
+++ b/build/cpm.js
@@ -2088,7 +2088,7 @@ var CPM = (function (exports) {
 		constructor( conf ){
 			super( conf );
 
-			this.cellpixelsbirth = {}; // time the pixel was added to its current cell.
+			this.cellpixelsact = {}; // activity of cellpixels with a non-zero activity
 			
 			// Wrapper: select function to compute activities based on ACT_MEAN in conf
 			if( this.conf.ACT_MEAN == "arithmetic" ){
@@ -2098,6 +2098,7 @@ var CPM = (function (exports) {
 			}
 			
 		}
+		
 		/* ======= ACT MODEL ======= */
 
 		/* Act model : compute local activity values within cell around pixel i.
@@ -2198,22 +2199,33 @@ var CPM = (function (exports) {
 		/* Current activity (under the Act model) of the pixel with ID i. */
 		pxact ( i ){
 		
-			// If the pixel is not in the cellpixelsbirth object, it has activity 0.
-			/*if ( !this.cellpixelsbirth[i] ){
+			// If the pixel is not in the cellpixelsact object, it has activity 0.
+			if ( this.cellpixelsact[i] == undefined ){
 				return 0
-			}*/
+			}
+			// otherwise, its activity is stored in the object.
+			return this.cellpixelsact[i]
 			
-			// cellkind of current pixel
-			const k = this.C.cellKind( this.C.pixti(i) );
-			
-			// Activity info
-			const actmax = this.conf["MAX_ACT"][k], age = (this.C.time - this.cellpixelsbirth[i]);
-
-			return (age > actmax) ? 0 : actmax-age
 		}
+		
 		/* eslint-disable no-unused-vars*/
 		postSetpixListener( i, t_old, t ){
-			this.cellpixelsbirth[i] = this.C.time;
+		
+			// After setting a pixel, it gets the MAX_ACT value of its cellkind.
+			const k = this.C.cellKind( t );
+			this.cellpixelsact[i] = this.conf["MAX_ACT"][k];
+		}
+		
+		postMCSListener(){
+			// iterate over cellpixelsage and decrease all activities by one.
+			for( let key in this.cellpixelsact ){
+				this.cellpixelsact[ key ] = this.cellpixelsact[ key ] - 1;
+				
+				// activities that reach zero no longer need to be stored.
+				if( this.cellpixelsact[ key ] <= 0 ){
+					delete this.cellpixelsact[ key ];
+				}
+			}
 		}
 
 

--- a/examples/actmodel.html
+++ b/examples/actmodel.html
@@ -7,14 +7,14 @@
 "use strict"
 
 let C, zoom=2, Cim, cid=0, w=200, meter
-let A = new CPM.ActivityConstraint( { MAX_ACT : [0,10],
-		LAMBDA_ACT: [0,100], ACT_MEAN: "geometric" } )
+let A = new CPM.ActivityConstraint( { MAX_ACT : [0,30],
+		LAMBDA_ACT: [0,300], ACT_MEAN: "geometric" } )
 
 function draw(){
 	// Clear the canvas (in the backgroundcolor white), and redraw:
 	Cim.clear( "FFFFFF" )
 	// The cell in red
-	Cim.drawCells( 1, "AA0000" )
+	Cim.drawCells( 1, "000000" )
 	Cim.drawActivityValues( 1, A )
 }
 
@@ -34,11 +34,12 @@ function initialize(){
 		T : 10
 	})
 
-	C.addTerm( new CPM.VolumeConstraint( { V: [0,500], 
+	C.add( new CPM.VolumeConstraint( { V: [0,500], 
 		LAMBDA_V: [0,5] } ) )
-	C.addTerm( new CPM.Adhesion( { J: [[0,10], [10,0]] } ) )
-	C.addTerm( A )
-
+	C.add( new CPM.Adhesion( { J: [[0,10], [10,0]] } ) )
+	C.add( A )
+	C.add( new CPM.PerimeterConstraint( { P: [0,260],
+		LAMBDA_P: [0,2] } ) )
 
 
 	let cid = C.makeNewCellID(1)
@@ -51,7 +52,7 @@ function initialize(){
 }
 </script>
 </head>
-<body onload="initialize()" onclick="seedGrid()">
-<p>Basic Potts (=Ising) model. Click on canvas to reset simulation</p>
+<body onload="initialize()">
+<h1>Basic Act model.</h1>
 </body>
 </html>

--- a/hamiltonian/ActivityConstraint2.js
+++ b/hamiltonian/ActivityConstraint2.js
@@ -1,0 +1,159 @@
+/* 
+	Implements the activity constraint of Potts models. 
+	See also: 
+		Niculescu I, Textor J, de Boer RJ (2015) 
+ 		Crawling and Gliding: A Computational Model for Shape-Driven Cell Migration. 
+ 		PLoS Comput Biol 11(10): e1004280. 
+ 		https://doi.org/10.1371/journal.pcbi.1004280
+ */
+
+import SoftConstraint from "./SoftConstraint.js"
+
+class ActivityConstraint extends SoftConstraint {
+	constructor( conf ){
+		super( conf )
+
+		this.cellpixelsact = {} // activity of cellpixels with a non-zero activity
+		
+		// Wrapper: select function to compute activities based on ACT_MEAN in conf
+		if( this.conf.ACT_MEAN == "arithmetic" ){
+			this.activityAt = this.activityAtArith
+		} else {
+			this.activityAt = this.activityAtGeom
+		}
+		
+	}
+	
+	/* ======= ACT MODEL ======= */
+
+	/* Act model : compute local activity values within cell around pixel i.
+	 * Depending on settings in conf, this is an arithmetic (activityAtArith)
+	 * or geometric (activityAtGeom) mean of the activities of the neighbors
+	 * of pixel i.
+	 */
+	/* Hamiltonian computation */ 
+	deltaH ( sourcei, targeti, src_type, tgt_type ){
+
+		let deltaH = 0, maxact, lambdaact
+		const src_kind = this.C.cellKind( src_type )
+		const tgt_kind = this.C.cellKind( tgt_type )
+
+		// use parameters for the source cell, unless that is the background.
+		// In that case, use parameters of the target cell.
+		if( src_type != 0 ){
+			maxact = this.conf["MAX_ACT"][src_kind]
+			lambdaact = this.conf["LAMBDA_ACT"][src_kind]
+		} else {
+			// special case: punishment for a copy attempt from background into
+			// an active cell. This effectively means that the active cell retracts,
+			// which is different from one cell pushing into another (active) cell.
+			maxact = this.conf["MAX_ACT"][tgt_kind]
+			lambdaact = this.conf["LAMBDA_ACT"][tgt_kind]
+		}
+		if( maxact == 0 || lambdaact == 0 ){
+			return 0
+		}
+
+		// compute the Hamiltonian. The activityAt method is a wrapper for either activityAtArith
+		// or activityAtGeom, depending on conf (see constructor).	
+		deltaH += lambdaact*(this.activityAt( targeti ) - this.activityAt( sourcei ))/maxact
+		return deltaH
+	}
+
+	/* Activity mean computation methods for arithmetic/geometric mean.
+	The method used by activityAt is defined by conf ( see constructor ).*/
+	activityAtArith( i ){
+		const t = this.C.pixti( i )
+		
+		// no activity for background/stroma
+		if( t <= 0 ){ return 0 }
+		
+		// neighborhood pixels
+		const N = this.C.neighi(i)
+		
+		// r activity summed, nN number of neighbors
+		// we start with the current pixel. 
+		let r = this.pxact(i), nN = 1
+		
+		// loop over neighbor pixels
+		for( let j = 0 ; j < N.length ; j ++ ){ 
+			const tn = this.C.pixti( N[j] ) 
+			
+			// a neighbor only contributes if it belongs to the same cell
+			if( tn == t ){
+				r += this.pxact( N[j] )
+				nN ++ 
+			}
+		}
+
+		// average is summed r divided by num neighbors.
+		return r/nN
+	}
+	activityAtGeom ( i ){
+		const t = this.C.pixti( i )
+
+		// no activity for background/stroma
+		if( t <= 0 ){ return 0 }
+		
+		//neighborhood pixels
+		const N = this.C.neighi( i )
+		
+		// r activity product, nN number of neighbors.
+		// we start with the current pixel.
+		let nN = 1, r = this.pxact( i )
+
+		// loop over neighbor pixels
+		for( let j = 0 ; j < N.length ; j ++ ){ 
+			const tn = this.C.pixti( N[j] ) 
+
+			// a neighbor only contributes if it belongs to the same cell.
+			// if it does and has activity 0, the product will also be zero so
+			// we can already return.
+			if( tn == t ){
+				if( this.pxact( N[j] ) == 0 ) return 0
+				r *= this.pxact( N[j] )
+				nN ++ 
+			}
+		}
+		
+		// Geometric mean computation. 
+		return Math.pow(r,1/nN)
+	}
+
+
+	/* Current activity (under the Act model) of the pixel with ID i. */
+	pxact ( i ){
+	
+		// If the pixel is not in the cellpixelsact object, it has activity 0.
+		if ( this.cellpixelsact[i] == undefined ){
+			return 0
+		}
+		// otherwise, its activity is stored in the object.
+		return this.cellpixelsact[i]
+		
+	}
+	
+	/* eslint-disable no-unused-vars*/
+	postSetpixListener( i, t_old, t ){
+	
+		// After setting a pixel, it gets the MAX_ACT value of its cellkind.
+		const k = this.C.cellKind( t )
+		this.cellpixelsact[i] = this.conf["MAX_ACT"][k]
+	}
+	
+	postMCSListener(){
+		// iterate over cellpixelsage and decrease all activities by one.
+		for( let key in this.cellpixelsact ){
+			this.cellpixelsact[ key ] = this.cellpixelsact[ key ] - 1
+			
+			// activities that reach zero no longer need to be stored.
+			if( this.cellpixelsact[ key ] <= 0 ){
+				delete this.cellpixelsact[ key ]
+			}
+		}
+	}
+
+
+}
+
+export default ActivityConstraint


### PR DESCRIPTION
This implementation should be better than the old one because it directly tracks the activity of active pixels and discards them from memory once their activity reaches zero. While the old implementation seems to work, but it never deletes any pixels from the cellpixelsbirth object. This would require a "postDelpixListener", which we currently don't have. So the birth of a pixel gets added to the object but is never removed, which will yield an unnecessarily large object in the long run. The new implementation should fix this issue.

**To do** Write the test that somehow compares the implementations to check for correctness.